### PR TITLE
Add timings on server node with multiple threads/processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,26 @@ This project benchmarks FourierFlows performance against other similar packages
 
 Results for `nx=ny=256` grid-points:
 
-On *CPU* (2.9 GHz Intel Core i7 Macbook Pro with 16 GB 2133 MHz LPDDR3, using one thread)
+On *laptop CPU* with 1 process/thread (2.9 GHz Intel Core i7 Macbook Pro with 16 GB 2133 MHz LPDDR3)
 
 | package        | Time per time-step  |
-| -------------  |:-------------:| 
+| -------------  |:-------------:|
 |[GeophysicalFlows.jl v0.3.0](https://github.com/FourierFlows/GeophysicalFlows.jl/tree/v0.3.0) | **1.58 ms** |
 |[pyqg v0.3.0+1.gb777817](https://github.com/pyqg/pyqg/tree/b777817ecc34893407585894e3c7ab1a6160c19c)|  **3.10 ms** |
 |matlab R2017a|  **9.28 ms** |
 |[dedalus v2.1905+](https://bitbucket.org/dedalus-project/dedalus/src/e3f973ecb5d1861b54d12e4500e2298593f23e4a/)|  **12.73 ms** |
 
+On *server CPU* (2.9 GHz Intel Cascade Lake 8268 with 768 GB 2666 MHz DDR4)
+
+| package        | Time per time-step  | Procs/threads (optimal)  |
+| -------------  |:-------------:|:-------------:|
+|[GeophysicalFlows.jl v0.5.0](https://github.com/FourierFlows/GeophysicalFlows.jl/tree/v0.5.0) | **1.829 ms** | 12 threads |
+|[dedalus v2.2006a1](https://github.com/DedalusProject/dedalus/commit/a8606126812b7034fb413693f8031777b38d0877)|  **2.062 ms** | 32 procs |
 
 On *GPU* (NVIDIA Tesla K40c GPU, 12GB)
 
 | package        | Time per time-step  |
-| -------------  |:-------------:| 
+| -------------  |:-------------:|
 |[GeophysicalFlows.jl #b15419e](https://github.com/FourierFlows/GeophysicalFlows.jl/tree/b15419e4fe093666c0b72cf1191328e631c5ed20) | **1.02 ms** |
 |matlab R2016b|  **0.975 ms** |
 
@@ -28,19 +34,25 @@ On *GPU* (NVIDIA Tesla K40c GPU, 12GB)
 
 Results for `nx=ny=1024` grid-points:
 
-On *CPU* (2.9 GHz Intel Core i7 Macbook Pro with 16 GB 2133 MHz LPDDR3, using one thread)
+On *laptop CPU* with 1 process/thread (2.9 GHz Intel Core i7 Macbook Pro with 16 GB 2133 MHz LPDDR3)
 
 | package        | Time per time-step  |
-| -------------  |:-------------:| 
+| -------------  |:-------------:|
 |[GeophysicalFlows.jl v0.3.0](https://github.com/FourierFlows/GeophysicalFlows.jl/tree/v0.3.0) | **44.29 ms** |
 |[pyqg v0.3.0+1.gb777817](https://github.com/pyqg/pyqg/tree/b777817ecc34893407585894e3c7ab1a6160c19c)|  **68.52 ms** |
 |matlab R2017a|  **271.92 ms** |
 |[dedalus v2.1905+](https://bitbucket.org/dedalus-project/dedalus/src/e3f973ecb5d1861b54d12e4500e2298593f23e4a/)|  **169.58 ms** |
 
+On *server CPU* (2.9 GHz Intel Cascade Lake 8268 with 768 GB 2666 MHz DDR4)
+
+| package        | Time per time-step  | Procs/threads (optimal)  |
+| -------------  |:-------------:|:-------------:|
+|[GeophysicalFlows.jl v0.5.0](https://github.com/FourierFlows/GeophysicalFlows.jl/tree/v0.5.0) | **25.64 ms** | 24 threads |
+|[dedalus v2.2006a1](https://github.com/DedalusProject/dedalus/commit/a8606126812b7034fb413693f8031777b38d0877)|  **7.139 ms** | 48 procs |
 
 On *GPU* (NVIDIA Tesla K40c GPU, 12GB)
 
 | package        | Time per time-step  |
-| -------------  |:-------------:| 
+| -------------  |:-------------:|
 | [GeophysicalFlows.jl #b15419e](https://github.com/FourierFlows/GeophysicalFlows.jl/tree/b15419e4fe093666c0b72cf1191328e631c5ed20) | **13.96 ms** |
 |matlab R2016b|  **7.353 ms** |

--- a/THREADING.md
+++ b/THREADING.md
@@ -1,0 +1,19 @@
+Threading performance of GeophysicalFlows on Flatiron Popeye cluster:
+
+N=1024
+1: 48.654 ms per time-step
+2: 47.953 ms per time-step
+4: 37.856 ms per time-step
+12: 27.95 ms per time-step
+24: 25.64 ms per time-step
+36: 34.79 ms per time-step
+48: 34.382 ms per time-step
+
+N=256
+1: 1.899 ms per time-step
+2: 2.964 ms per time-step
+4: 2.432 ms per time-step
+12: 1.829 ms per time-step
+24: 2.193 ms per time-step
+36: 3.35 ms per time-step
+48: 3.487 ms per time-step

--- a/THREADING.md
+++ b/THREADING.md
@@ -1,19 +1,33 @@
 Threading performance of GeophysicalFlows on Flatiron Popeye cluster:
 
-N=1024
-1: 48.654 ms per time-step
-2: 47.953 ms per time-step
-4: 37.856 ms per time-step
-12: 27.95 ms per time-step
-24: 25.64 ms per time-step
-36: 34.79 ms per time-step
-48: 34.382 ms per time-step
+N=1024  
+1: 48.654 ms per time-step  
+2: 47.953 ms per time-step  
+4: 37.856 ms per time-step  
+12: 27.95 ms per time-step  
+24: 25.64 ms per time-step  
+36: 34.79 ms per time-step  
+48: 34.382 ms per time-step  
 
-N=256
-1: 1.899 ms per time-step
-2: 2.964 ms per time-step
-4: 2.432 ms per time-step
-12: 1.829 ms per time-step
-24: 2.193 ms per time-step
-36: 3.35 ms per time-step
-48: 3.487 ms per time-step
+N=256  
+1: 1.899 ms per time-step  
+2: 2.964 ms per time-step  
+4: 2.432 ms per time-step  
+12: 1.829 ms per time-step  
+24: 2.193 ms per time-step  
+36: 3.35 ms per time-step  
+48: 3.487 ms per time-step  
+
+MPI performance of Dedalus on Flatiron Popeye cluster:
+
+N=1024  
+16: 14.386 ms per time-step  
+24: 10.981 ms per time-step  
+32: 8.783 ms per time-step  
+48: 7.193 ms per time-step  
+
+N=256  
+16: 2.333 ms per time-step  
+24: 2.253 ms per time-step  
+32: 2.062 ms  per time-step  
+48: 2.376 ms per time-step  


### PR DESCRIPTION
@glwagner and I tested Dedalus with multiple processes and GeophysicalFlows.jl with multiple threads on a compute node on one of the Flatiron clusters, which might be a better baseline to compare against the GPU results.  We ran both N=256 and N=1024 with a range of threads/processes and recorded the timings in the new THREADING.md file.  I've added the optimal timings for each code and resolution to new tables in README.md.

Addresses issue #7 .